### PR TITLE
Declare inline functions as extern

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -81,8 +81,10 @@ libmee_@MACHINE_NAME@_a_SOURCES = \
 	src/drivers/sifive,gpio0.c \
 	src/drivers/sifive,uart0.c \
 	src/before_main.c \
+	src/clock.c \
 	src/tty.c \
 	src/shutdown.c \
+	src/uart.c \
 	src/entry.S
 
 # Quash an automake warning.

--- a/mee/clock.h
+++ b/mee/clock.h
@@ -23,12 +23,12 @@ struct mee_clock {
 };
 
 /* Returns the current rate of the given clock. */
-inline long mee_clock_get_rate_hz(const struct mee_clock *clk) { return clk->vtable->get_rate_hz(clk); }
+extern inline long mee_clock_get_rate_hz(const struct mee_clock *clk) { return clk->vtable->get_rate_hz(clk); }
 
 /* Attempts to set the current rate of the given clock to as close as possible
  * to the given rate.  Returns the actual value that's been selected, which
  * could be anything! */
-inline long mee_clock_set_rate_hz(struct mee_clock *clk, long hz)
+extern inline long mee_clock_set_rate_hz(struct mee_clock *clk, long hz)
 {
     long out = clk->vtable->set_rate_hz(clk, hz);
     if (clk->rate_change_callback != NULL)
@@ -37,7 +37,7 @@ inline long mee_clock_set_rate_hz(struct mee_clock *clk, long hz)
 }
 
 /* Registers a callback that must be called whenever. */
-inline void mee_clock_register_rate_change_callback(struct mee_clock *clk, mee_clock_rate_change_callback cb, void *priv)
+extern inline void mee_clock_register_rate_change_callback(struct mee_clock *clk, mee_clock_rate_change_callback cb, void *priv)
 {
     clk->rate_change_callback = cb;
     clk->rate_change_callback_priv = priv;

--- a/mee/uart.h
+++ b/mee/uart.h
@@ -19,14 +19,14 @@ struct mee_uart {
 };
 
 /* Initializes a UART. */
-static inline void mee_uart_init(struct mee_uart *uart, int baud_rate) { return uart->vtable->init(uart, baud_rate); }
+extern inline void mee_uart_init(struct mee_uart *uart, int baud_rate) { return uart->vtable->init(uart, baud_rate); }
 
 /* Reads from or writes to a UART.  These return 0 on success. */
-static inline int mee_uart_putc(struct mee_uart *uart, unsigned char c) { return uart->vtable->putc(uart, c); }
-static inline int mee_uart_getc(struct mee_uart *uart, unsigned char *c) { return uart->vtable->getc(uart, c); }
+extern inline int mee_uart_putc(struct mee_uart *uart, unsigned char c) { return uart->vtable->putc(uart, c); }
+extern inline int mee_uart_getc(struct mee_uart *uart, unsigned char *c) { return uart->vtable->getc(uart, c); }
 
 /* Modifies (or allows probing of) the UART's current baud rate. */
-static inline int mee_uart_get_baud_rate(struct mee_uart *uart) { return uart->vtable->get_baud_rate(uart); }
-static inline int mee_uart_set_baud_rate(struct mee_uart *uart, int baud_rate) { return uart->vtable->set_baud_rate(uart, baud_rate); }
+extern inline int mee_uart_get_baud_rate(struct mee_uart *uart) { return uart->vtable->get_baud_rate(uart); }
+extern inline int mee_uart_set_baud_rate(struct mee_uart *uart, int baud_rate) { return uart->vtable->set_baud_rate(uart, baud_rate); }
 
 #endif

--- a/src/clock.c
+++ b/src/clock.c
@@ -1,0 +1,8 @@
+/* Copyright 2018 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <mee/clock.h>
+
+extern inline long mee_clock_get_rate_hz(const struct mee_clock *clk);
+extern inline long mee_clock_set_rate_hz(struct mee_clock *clk, long hz);
+extern inline void mee_clock_register_rate_change_callback(struct mee_clock *clk, mee_clock_rate_change_callback cb, void *priv);

--- a/src/uart.c
+++ b/src/uart.c
@@ -1,0 +1,10 @@
+/* Copyright 2018 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <mee/uart.h>
+
+extern inline void mee_uart_init(struct mee_uart *uart, int baud_rate);
+extern inline int mee_uart_putc(struct mee_uart *uart, unsigned char c);
+extern inline int mee_uart_getc(struct mee_uart *uart, unsigned char *c);
+extern inline int mee_uart_get_baud_rate(struct mee_uart *uart);
+extern inline int mee_uart_set_baud_rate(struct mee_uart *uart, int baud_rate);


### PR DESCRIPTION
Without this we get undefined references to these symbols when GCC
decides not to inline them.  I'd avoid declaring them as "static inline"
because I didn't want to increase code size too much.

Signed-off-by: Palmer Dabbelt <palmer@sifive.com>