### PR TITLE
Use "extern inline" for all inline functions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -81,8 +81,10 @@ libmee_@MACHINE_NAME@_a_SOURCES = \
 	src/drivers/sifive,gpio0.c \
 	src/drivers/sifive,uart0.c \
 	src/before_main.c \
+	src/clock.c \
 	src/tty.c \
 	src/shutdown.c \
+	src/uart.c \
 	src/entry.S
 
 # Quash an automake warning.

--- a/mee/shutdown.h
+++ b/mee/shutdown.h
@@ -14,8 +14,8 @@ struct mee_shutdown {
     const struct mee_shutdown_vtable *vtable;
 };
 
-static inline void mee_shutdown_exit(const struct mee_shutdown *sd, int code) __attribute__((noreturn));
-static inline void mee_shutdown_exit(const struct mee_shutdown *sd, int code) { sd->vtable->exit(sd, code); }
+inline void mee_shutdown_exit(const struct mee_shutdown *sd, int code) __attribute__((noreturn));
+inline void mee_shutdown_exit(const struct mee_shutdown *sd, int code) { sd->vtable->exit(sd, code); }
 
 /* The public MEE shutdown interface, which allows us to turn off the machine
  * when posible. */

--- a/mee/uart.h
+++ b/mee/uart.h
@@ -19,14 +19,14 @@ struct mee_uart {
 };
 
 /* Initializes a UART. */
-static inline void mee_uart_init(struct mee_uart *uart, int baud_rate) { return uart->vtable->init(uart, baud_rate); }
+inline void mee_uart_init(struct mee_uart *uart, int baud_rate) { return uart->vtable->init(uart, baud_rate); }
 
 /* Reads from or writes to a UART.  These return 0 on success. */
-static inline int mee_uart_putc(struct mee_uart *uart, unsigned char c) { return uart->vtable->putc(uart, c); }
-static inline int mee_uart_getc(struct mee_uart *uart, unsigned char *c) { return uart->vtable->getc(uart, c); }
+inline int mee_uart_putc(struct mee_uart *uart, unsigned char c) { return uart->vtable->putc(uart, c); }
+inline int mee_uart_getc(struct mee_uart *uart, unsigned char *c) { return uart->vtable->getc(uart, c); }
 
 /* Modifies (or allows probing of) the UART's current baud rate. */
-static inline int mee_uart_get_baud_rate(struct mee_uart *uart) { return uart->vtable->get_baud_rate(uart); }
-static inline int mee_uart_set_baud_rate(struct mee_uart *uart, int baud_rate) { return uart->vtable->set_baud_rate(uart, baud_rate); }
+inline int mee_uart_get_baud_rate(struct mee_uart *uart) { return uart->vtable->get_baud_rate(uart); }
+inline int mee_uart_set_baud_rate(struct mee_uart *uart, int baud_rate) { return uart->vtable->set_baud_rate(uart, baud_rate); }
 
 #endif

--- a/src/clock.c
+++ b/src/clock.c
@@ -1,0 +1,8 @@
+/* Copyright 2018 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <mee/clock.h>
+
+extern inline long mee_clock_get_rate_hz(const struct mee_clock *clk);
+extern inline long mee_clock_set_rate_hz(struct mee_clock *clk, long hz);
+extern inline void mee_clock_register_rate_change_callback(struct mee_clock *clk, mee_clock_rate_change_callback cb, void *priv);

--- a/src/shutdown.c
+++ b/src/shutdown.c
@@ -3,6 +3,8 @@
 
 #include <mee/shutdown.h>
 
+extern inline void mee_shutdown_exit(const struct mee_shutdown *sd, int code);
+
 #if defined(__MEE_DT_SHUTDOWN_HANDLE)
 void mee_shutdown(int code)
 {

--- a/src/uart.c
+++ b/src/uart.c
@@ -1,0 +1,10 @@
+/* Copyright 2018 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <mee/uart.h>
+
+extern inline void mee_uart_init(struct mee_uart *uart, int baud_rate);
+extern inline int mee_uart_putc(struct mee_uart *uart, unsigned char c);
+extern inline int mee_uart_getc(struct mee_uart *uart, unsigned char *c);
+extern inline int mee_uart_get_baud_rate(struct mee_uart *uart);
+extern inline int mee_uart_set_baud_rate(struct mee_uart *uart, int baud_rate);


### PR DESCRIPTION
This allows these small functions to be inlined into user code if the
compiler chooses to do so, while also providing definitions in case the
compiler doesn't want to inline them.

Signed-off-by: Palmer Dabbelt <palmer@sifive.com>