### PR TITLE
Use the "abs()" from <stdlib.h>

### DIFF
--- a/mee/compiler.h
+++ b/mee/compiler.h
@@ -11,9 +11,4 @@
 #define __MEE_GET_FIELD(reg, mask)                        \
     (((reg) & (mask)) / ((mask) & ~((mask) << 1)))
 
-static inline long abs(long val)
-{
-    return (val >= 0 ? val : val * -1);
-}
-
 #endif

--- a/src/drivers/sifive,fe310-g000,pll.c
+++ b/src/drivers/sifive,fe310-g000,pll.c
@@ -5,7 +5,7 @@
 #include <limits.h>
 
 #include <mee/drivers/sifive,fe310-g000,pll.h>
-#include <mee/compiler.h>
+#include <stdlib.h>
 
 #define PLL_R        0x00000007UL
 #define PLL_F        0x000003F0UL


### PR DESCRIPTION
This avoids a compilation warning.

Signed-off-by: Palmer Dabbelt <palmer@sifive.com>