### PR TITLE
 Add --with-bultin-libgloss, to build a libgloss

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -103,10 +103,13 @@ mee/machine/@MACHINE_NAME@.h: @MEE_HEADER_GENERATOR@ @MACHINE_NAME@.dtb
 	$< --dtb $(filter %.dtb,$^) --output $@
 endif # PRECONFIGURED
 
+# Quash an automake warning.
+lib_LIBRARIES =
+
 # Everything in here is compiled into a single library, which contains all the
 # source files in the project.  It's named for one specific machine, which GCC
 # uses to select the target machine that this MEE implementation points at.
-lib_LIBRARIES = libriscv__mmachine__@MACHINE_NAME@.a
+lib_LIBRARIES += libriscv__mmachine__@MACHINE_NAME@.a
 
 libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS  = @MENV_MEE@ @MMACHINE_MACHINE_NAME@
 libriscv__mmachine__@MACHINE_NAME@_a_CCASFLAGS = @MENV_MEE@ @MMACHINE_MACHINE_NAME@
@@ -125,6 +128,49 @@ libriscv__mmachine__@MACHINE_NAME@_a_SOURCES = \
 	src/shutdown.c \
 	src/uart.c \
 	src/entry.S
+
+# Freedom MEE has its own libgloss implementation that is only built in
+# --with-builtin-libgloss is passed to configure.
+if WITH_BUILTIN_LIBGLOSS
+
+lib_LIBRARIES += libriscv__menv__mee.a
+
+libriscv__menv__mee_a_SOURCES = \
+	gloss/nanosleep.c \
+	gloss/sys_access.c \
+	gloss/sys_chdir.c \
+	gloss/sys_chmod.c \
+	gloss/sys_chown.c \
+	gloss/sys_close.c \
+	gloss/sys_execve.c \
+	gloss/sys_exit.c \
+	gloss/sys_faccessat.c \
+	gloss/sys_fork.c \
+	gloss/sys_fstat.c \
+	gloss/sys_fstatat.c \
+	gloss/sys_ftime.c \
+	gloss/sys_getcwd.c \
+	gloss/sys_getpid.c \
+	gloss/sys_gettimeofday.c \
+	gloss/sys_isatty.c \
+	gloss/sys_kill.c \
+	gloss/sys_link.c \
+	gloss/sys_lseek.c \
+	gloss/sys_lstat.c \
+	gloss/sys_open.c \
+	gloss/sys_openat.c \
+	gloss/sys_read.c \
+	gloss/sys_sbrk.c \
+	gloss/sys_stat.c \
+	gloss/sys_sysconf.c \
+	gloss/sys_times.c \
+	gloss/sys_unlink.c \
+	gloss/sys_utime.c \
+	gloss/sys_wait.c \
+	gloss/sys_write.c \
+	gloss/crt0.S
+
+endif
 
 # Quash an automake warning.
 check_PROGRAMS =

--- a/Makefile.in
+++ b/Makefile.in
@@ -91,6 +91,10 @@ POST_INSTALL = :
 NORMAL_UNINSTALL = :
 PRE_UNINSTALL = :
 POST_UNINSTALL = :
+
+# Freedom MEE has its own libgloss implementation that is only built in
+# --with-builtin-libgloss is passed to configure.
+@WITH_BUILTIN_LIBGLOSS_TRUE@am__append_1 = libriscv__menv__mee.a
 check_PROGRAMS = return_pass$(EXEEXT) return_fail$(EXEEXT) \
 	hello$(EXEEXT) pll_set_hz$(EXEEXT)
 subdir = .
@@ -142,9 +146,58 @@ AM_V_AR = $(am__v_AR_@AM_V@)
 am__v_AR_ = $(am__v_AR_@AM_DEFAULT_V@)
 am__v_AR_0 = @echo "  AR      " $@;
 am__v_AR_1 = 
+libriscv__menv__mee_a_AR = $(AR) $(ARFLAGS)
+libriscv__menv__mee_a_LIBADD =
+am__libriscv__menv__mee_a_SOURCES_DIST = gloss/nanosleep.c \
+	gloss/sys_access.c gloss/sys_chdir.c gloss/sys_chmod.c \
+	gloss/sys_chown.c gloss/sys_close.c gloss/sys_execve.c \
+	gloss/sys_exit.c gloss/sys_faccessat.c gloss/sys_fork.c \
+	gloss/sys_fstat.c gloss/sys_fstatat.c gloss/sys_ftime.c \
+	gloss/sys_getcwd.c gloss/sys_getpid.c gloss/sys_gettimeofday.c \
+	gloss/sys_isatty.c gloss/sys_kill.c gloss/sys_link.c \
+	gloss/sys_lseek.c gloss/sys_lstat.c gloss/sys_open.c \
+	gloss/sys_openat.c gloss/sys_read.c gloss/sys_sbrk.c \
+	gloss/sys_stat.c gloss/sys_sysconf.c gloss/sys_times.c \
+	gloss/sys_unlink.c gloss/sys_utime.c gloss/sys_wait.c \
+	gloss/sys_write.c gloss/crt0.S
+am__dirstamp = $(am__leading_dot)dirstamp
+@WITH_BUILTIN_LIBGLOSS_TRUE@am_libriscv__menv__mee_a_OBJECTS =  \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/nanosleep.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_access.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_chdir.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_chmod.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_chown.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_close.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_execve.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_exit.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_faccessat.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_fork.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_fstat.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_fstatat.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_ftime.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_getcwd.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_getpid.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_gettimeofday.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_isatty.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_kill.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_link.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_lseek.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_lstat.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_open.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_openat.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_read.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_sbrk.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_stat.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_sysconf.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_times.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_unlink.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_utime.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_wait.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_write.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/crt0.$(OBJEXT)
+libriscv__menv__mee_a_OBJECTS = $(am_libriscv__menv__mee_a_OBJECTS)
 libriscv__mmachine__@MACHINE_NAME@_a_AR = $(AR) $(ARFLAGS)
 libriscv__mmachine__@MACHINE_NAME@_a_LIBADD =
-am__dirstamp = $(am__leading_dot)dirstamp
 am_libriscv__mmachine__@MACHINE_NAME@_a_OBJECTS = src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-clock.$(OBJEXT) \
 	src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-sifive,fe310-g000,hfrosc.$(OBJEXT) \
 	src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-sifive,fe310-g000,hfxosc.$(OBJEXT) \
@@ -218,10 +271,12 @@ AM_V_CCLD = $(am__v_CCLD_@AM_V@)
 am__v_CCLD_ = $(am__v_CCLD_@AM_DEFAULT_V@)
 am__v_CCLD_0 = @echo "  CCLD    " $@;
 am__v_CCLD_1 = 
-SOURCES = $(libriscv__mmachine__@MACHINE_NAME@_a_SOURCES) \
+SOURCES = $(libriscv__menv__mee_a_SOURCES) \
+	$(libriscv__mmachine__@MACHINE_NAME@_a_SOURCES) \
 	$(hello_SOURCES) $(pll_set_hz_SOURCES) $(return_fail_SOURCES) \
 	$(return_pass_SOURCES)
-DIST_SOURCES = $(libriscv__mmachine__@MACHINE_NAME@_a_SOURCES) \
+DIST_SOURCES = $(am__libriscv__menv__mee_a_SOURCES_DIST) \
+	$(libriscv__mmachine__@MACHINE_NAME@_a_SOURCES) \
 	$(hello_SOURCES) $(pll_set_hz_SOURCES) $(return_fail_SOURCES) \
 	$(return_pass_SOURCES)
 am__can_run_installinfo = \
@@ -404,10 +459,12 @@ nobase_include_HEADERS = \
 	mee/uart.h
 
 
+# Quash an automake warning.
+
 # Everything in here is compiled into a single library, which contains all the
 # source files in the project.  It's named for one specific machine, which GCC
 # uses to select the target machine that this MEE implementation points at.
-lib_LIBRARIES = libriscv__mmachine__@MACHINE_NAME@.a
+lib_LIBRARIES = libriscv__mmachine__@MACHINE_NAME@.a $(am__append_1)
 libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS = @MENV_MEE@ @MMACHINE_MACHINE_NAME@
 libriscv__mmachine__@MACHINE_NAME@_a_CCASFLAGS = @MENV_MEE@ @MMACHINE_MACHINE_NAME@
 libriscv__mmachine__@MACHINE_NAME@_a_SOURCES = \
@@ -424,6 +481,41 @@ libriscv__mmachine__@MACHINE_NAME@_a_SOURCES = \
 	src/shutdown.c \
 	src/uart.c \
 	src/entry.S
+
+@WITH_BUILTIN_LIBGLOSS_TRUE@libriscv__menv__mee_a_SOURCES = \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/nanosleep.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_access.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_chdir.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_chmod.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_chown.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_close.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_execve.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_exit.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_faccessat.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_fork.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_fstat.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_fstatat.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_ftime.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_getcwd.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_getpid.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_gettimeofday.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_isatty.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_kill.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_link.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_lseek.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_lstat.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_open.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_openat.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_read.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_sbrk.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_stat.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_sysconf.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_times.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_unlink.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_utime.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_wait.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_write.c \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/crt0.S
 
 return_pass_SOURCES = test/return_pass.c
 return_pass_CFLAGS = @MENV_MEE@ @MMACHINE_MACHINE_NAME@
@@ -505,6 +597,83 @@ uninstall-libLIBRARIES:
 
 clean-libLIBRARIES:
 	-test -z "$(lib_LIBRARIES)" || rm -f $(lib_LIBRARIES)
+gloss/$(am__dirstamp):
+	@$(MKDIR_P) gloss
+	@: > gloss/$(am__dirstamp)
+gloss/$(DEPDIR)/$(am__dirstamp):
+	@$(MKDIR_P) gloss/$(DEPDIR)
+	@: > gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/nanosleep.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_access.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_chdir.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_chmod.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_chown.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_close.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_execve.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_exit.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_faccessat.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_fork.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_fstat.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_fstatat.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_ftime.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_getcwd.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_getpid.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_gettimeofday.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_isatty.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_kill.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_link.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_lseek.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_lstat.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_open.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_openat.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_read.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_sbrk.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_stat.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_sysconf.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_times.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_unlink.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_utime.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_wait.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/sys_write.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/crt0.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+
+libriscv__menv__mee.a: $(libriscv__menv__mee_a_OBJECTS) $(libriscv__menv__mee_a_DEPENDENCIES) $(EXTRA_libriscv__menv__mee_a_DEPENDENCIES) 
+	$(AM_V_at)-rm -f libriscv__menv__mee.a
+	$(AM_V_AR)$(libriscv__menv__mee_a_AR) libriscv__menv__mee.a $(libriscv__menv__mee_a_OBJECTS) $(libriscv__menv__mee_a_LIBADD)
+	$(AM_V_at)$(RANLIB) libriscv__menv__mee.a
 src/drivers/$(am__dirstamp):
 	@$(MKDIR_P) src/drivers
 	@: > src/drivers/$(am__dirstamp)
@@ -592,6 +761,7 @@ return_pass$(EXEEXT): $(return_pass_OBJECTS) $(return_pass_DEPENDENCIES) $(EXTRA
 
 mostlyclean-compile:
 	-rm -f *.$(OBJEXT)
+	-rm -f gloss/*.$(OBJEXT)
 	-rm -f src/*.$(OBJEXT)
 	-rm -f src/drivers/*.$(OBJEXT)
 	-rm -f test/*.$(OBJEXT)
@@ -599,6 +769,39 @@ mostlyclean-compile:
 distclean-compile:
 	-rm -f *.tab.c
 
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/crt0.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/nanosleep.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_access.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_chdir.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_chmod.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_chown.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_close.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_execve.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_exit.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_faccessat.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_fork.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_fstat.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_fstatat.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_ftime.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_getcwd.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_getpid.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_gettimeofday.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_isatty.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_kill.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_link.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_lseek.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_lstat.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_open.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_openat.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_read.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_sbrk.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_stat.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_sysconf.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_times.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_unlink.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_utime.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_wait.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_write.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-clock.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-entry.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-shutdown.Po@am__quote@
@@ -1209,6 +1412,8 @@ clean-generic:
 distclean-generic:
 	-test -z "$(CONFIG_CLEAN_FILES)" || rm -f $(CONFIG_CLEAN_FILES)
 	-test . = "$(srcdir)" || test -z "$(CONFIG_CLEAN_VPATH_FILES)" || rm -f $(CONFIG_CLEAN_VPATH_FILES)
+	-rm -f gloss/$(DEPDIR)/$(am__dirstamp)
+	-rm -f gloss/$(am__dirstamp)
 	-rm -f src/$(DEPDIR)/$(am__dirstamp)
 	-rm -f src/$(am__dirstamp)
 	-rm -f src/drivers/$(DEPDIR)/$(am__dirstamp)
@@ -1226,7 +1431,7 @@ clean-am: clean-checkPROGRAMS clean-generic clean-libLIBRARIES \
 
 distclean: distclean-am
 	-rm -f $(am__CONFIG_DISTCLEAN_FILES)
-	-rm -rf src/$(DEPDIR) src/drivers/$(DEPDIR) test/$(DEPDIR)
+	-rm -rf gloss/$(DEPDIR) src/$(DEPDIR) src/drivers/$(DEPDIR) test/$(DEPDIR)
 	-rm -f Makefile
 distclean-am: clean-am distclean-compile distclean-generic \
 	distclean-tags
@@ -1275,7 +1480,7 @@ installcheck-am:
 maintainer-clean: maintainer-clean-am
 	-rm -f $(am__CONFIG_DISTCLEAN_FILES)
 	-rm -rf $(top_srcdir)/autom4te.cache
-	-rm -rf src/$(DEPDIR) src/drivers/$(DEPDIR) test/$(DEPDIR)
+	-rm -rf gloss/$(DEPDIR) src/$(DEPDIR) src/drivers/$(DEPDIR) test/$(DEPDIR)
 	-rm -f Makefile
 maintainer-clean-am: distclean-am maintainer-clean-generic
 

--- a/configure
+++ b/configure
@@ -600,6 +600,8 @@ MAKEATTRIBUTES_GENERATOR
 LDSCRIPT_GENERATOR
 MEE_HEADER_GENERATOR
 DTC
+WITH_BUILTIN_LIBGLOSS_FALSE
+WITH_BUILTIN_LIBGLOSS_TRUE
 MACHINE_NAME
 am__fastdepCCAS_FALSE
 am__fastdepCCAS_TRUE
@@ -700,6 +702,7 @@ enable_maintainer_mode
 enable_dependency_tracking
 with_machine_name
 with_preconfigured
+with_builtin_libgloss
 with_machine_header
 with_machine_ldscript
 with_machine_dts
@@ -1355,6 +1358,7 @@ Optional Packages:
                           Install this machine with a particular name
   --with-preconfigured    Use pre-configured machine support files instead of
                           generating them during the build
+  --with-bultin-libgloss  Build libgloss along with the MEE
   --with-machine-header=PATH
                           Path to the machine header file
   --with-machine-ldscript=PATH
@@ -3848,6 +3852,25 @@ else
 fi
 
 
+
+# Check whether --with-builtin-libgloss was given.
+if test "${with_builtin_libgloss+set}" = set; then :
+  withval=$with_builtin_libgloss; with_builtin_libgloss="yes"
+else
+  with_builtin_libgloss="no"
+
+fi
+
+
+ if test "x$with_builtin_libgloss" = "xyes"; then
+  WITH_BUILTIN_LIBGLOSS_TRUE=
+  WITH_BUILTIN_LIBGLOSS_FALSE='#'
+else
+  WITH_BUILTIN_LIBGLOSS_TRUE='#'
+  WITH_BUILTIN_LIBGLOSS_FALSE=
+fi
+
+
 ########################################################
 # Preconfigured Options (--with-preconfigured)
 ########################################################
@@ -4550,6 +4573,10 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${am__fastdepCCAS_TRUE}" && test -z "${am__fastdepCCAS_FALSE}"; then
   as_fn_error $? "conditional \"am__fastdepCCAS\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${WITH_BUILTIN_LIBGLOSS_TRUE}" && test -z "${WITH_BUILTIN_LIBGLOSS_FALSE}"; then
+  as_fn_error $? "conditional \"WITH_BUILTIN_LIBGLOSS\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${PRECONFIGURED_TRUE}" && test -z "${PRECONFIGURED_FALSE}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,14 @@ AC_ARG_WITH([preconfigured],
     [with_preconfigured="no"]
 )
 
+AC_ARG_WITH([builtin-libgloss],
+    [AS_HELP_STRING([--with-bultin-libgloss], [Build libgloss along with the MEE])],
+    [with_builtin_libgloss="yes"],
+    [with_builtin_libgloss="no"]
+)
+
+AM_CONDITIONAL([WITH_BUILTIN_LIBGLOSS], [test "x$with_builtin_libgloss" = "xyes"])
+
 ########################################################
 # Preconfigured Options (--with-preconfigured)
 ########################################################

--- a/gloss/crt0.S
+++ b/gloss/crt0.S
@@ -1,0 +1,147 @@
+/* Copyright (c) 2017-2018  SiFive Inc. All rights reserved.
+
+   This copyrighted material is made available to anyone wishing to use,
+   modify, copy, or redistribute it subject to the terms and conditions
+   of the FreeBSD License.   This program is distributed in the hope that
+   it will be useful, but WITHOUT ANY WARRANTY expressed or implied,
+   including the implied warranties of MERCHANTABILITY or FITNESS FOR
+   A PARTICULAR PURPOSE.  A copy of this license is available at
+   http://www.opensource.org/licenses.
+*/
+
+/* crt0.S: Entry point for RISC-V MEE programs. */
+
+.section .text.libgloss.start
+.global _start
+.type   _start, @function
+
+  /* _start is defined by the MEE to have been called with the following
+   * arguments:
+   *   a0: the hart ID of the currently executing hart.  Harts can start at
+   *       any arbitrary point, it's the C library's job to ensure the code is
+   *       safe.
+   *   a1: a pointer to a description of the machine on which this code is
+   *       currently executing.  This is probably 0 on an embedded system
+   *       because they tend to not be dynamically portable.  As such, newlib
+   *       ignores this argument.
+   *   a2: a pointer to a function that must be run after the envirnoment has
+   *       been initialized, but before user code can be expected to be run.
+   *       If this is 0 then there is no function to be run. */
+_start:
+.cfi_startproc
+.cfi_undefined ra
+
+  /* This is a bit funky: it's not usually sane for _start to return, but in
+   * this case we actually want to in order to signal an error to the MEE. */
+  mv s0, ra
+
+  /* Before doing anything we must initialize the global pointer, as we cannot
+   * safely perform any access that may be relaxed without GP being set.  This
+   * is done with relaxation disabled to avoid relaxing the address calculation
+   * to just "addi gp, gp, 0". */
+.option push
+.option norelax
+  la gp, __global_pointer$
+.option pop
+
+  /* The MEE is designed for a bare-metal environment and therefor is expected
+   * to define its own stack pointer.  We also align the stack pointer here
+   * because the only RISC-V ABI that's currently defined mandates 16-byte
+   * stack alignment. */
+  la sp, mee_segment_stack_end
+  andi sp, sp, -16
+
+  /* For now we only run on single-hart systems and assume that we're always on
+   * hart 0. */
+1:
+  bnez a0, 1b
+
+  /* Embedded systems frequently require relocating the data segment before C
+   * code can be run -- for example, the data segment may exist in flash upon
+   * boot and then need to get relocated into a non-persistant writable memory
+   * before C code can execute.  If this is the case we do so here.  This step
+   * is optional: if the MEE provides an environment in which this relocation
+   * is not necessary then it must simply set mee_segment_data_source_start to
+   * be equal to mee_segment_data_target_start. */
+  la t0, mee_segment_data_source_start
+  la t1, mee_segment_data_target_start
+  la t2, mee_segment_data_target_end
+
+  beq t0, t1, 2f
+  bge t1, t2, 2f
+
+1:
+  lw   t3, 0(t0)
+  addi t0, t0, 4
+  sw   t3, 0(t1)
+  addi t1, t1, 4
+  blt  t1, t2, 1b
+2:
+
+  /* Zero the BSS segment. */
+  la t1, mee_segment_bss_target_start
+  la t2, mee_segment_bss_target_end
+
+  bge t1, t2, 2f
+
+1:
+  sw   x0, 0(t1)
+  addi t1, t1, 4
+  blt  t1, t2, 1b
+2:
+
+  /* At this point we're in an environment that can execute C code.  The first
+   * thing to do is to make the callback to the parent environment if it's been
+   * requested to do so. */
+  beqz a2, 1f
+  jalr a2
+1:
+
+  /* The RISC-V port only uses new-style constructors and destructors. */
+  la a0, __libc_fini_array
+  call atexit
+  call __libc_init_array
+
+  /* This is a C runtime, so main() is defined to have some arguments.  Since
+   * there's nothing sane the MEE can pass we don't bother with that but
+   * instead just setup as close to a NOP as we can. */
+  li a0, 1     /* argc=1 */
+  la a1, argv  /* argv = {"libgloss", NULL} */
+  la a2, envp  /* envp = {NULL} */
+  call main
+
+  /* Call exit to handle libc's cleanup routines.  Under normal contains this
+   * shouldn't even get called, but I'm still not using a tail call here
+   * because returning to the MEE is the right thing to do in pathological
+   * situations. */
+  call exit
+
+  /* And here's where we return.  Again, it's a bit odd but the MEE defines
+   * this as a bad idea (ie, as opposed to leaving it undefined) and at this
+   * point it's really the only thing left to do. */
+  mv ra, s0
+  ret
+
+.cfi_endproc
+
+/* RISC-V systems always use __libc_{init,fini}_array, but for compatibility we
+ * define _{init,fini} to do nothing. */
+.global _init
+.type   _init, @function
+.global _fini
+.type   _fini, @function
+_init:
+_fini:
+  ret
+.size _init, .-_init
+.size _fini, .-_fini
+
+/* This shim allows main() to be passed a set of arguments that can satisfy the
+ * requirements of the C API. */
+.section .rodata.libgloss.start
+argv:
+.dc.a name
+envp:
+.dc.a 0
+name:
+.asciz "libgloss"

--- a/gloss/nanosleep.c
+++ b/gloss/nanosleep.c
@@ -1,0 +1,9 @@
+#include <errno.h>
+#include <sys/time.h>
+
+int
+nanosleep(const struct timespec *rqtp, struct timespec *rmtp)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_access.c
+++ b/gloss/sys_access.c
@@ -1,0 +1,8 @@
+#include <errno.h>
+
+int
+_access(const char *file, int mode)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_chdir.c
+++ b/gloss/sys_chdir.c
@@ -1,0 +1,8 @@
+#include <errno.h>
+
+int
+_chdir(const char *path)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_chmod.c
+++ b/gloss/sys_chmod.c
@@ -1,0 +1,9 @@
+#include <errno.h>
+#include <sys/types.h>
+
+int
+_chmod(const char *path, mode_t mode)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_chown.c
+++ b/gloss/sys_chown.c
@@ -1,0 +1,9 @@
+#include <sys/types.h>
+#include <errno.h>
+
+int
+_chown(const char *path, uid_t owner, gid_t group)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_close.c
+++ b/gloss/sys_close.c
@@ -1,0 +1,8 @@
+#include <errno.h>
+
+int
+_close(int file)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_execve.c
+++ b/gloss/sys_execve.c
@@ -1,0 +1,8 @@
+#include <errno.h>
+
+int
+_execve(const char *name, char *const argv[], char *const env[])
+{
+  errno = ENOMEM;
+  return -1;
+}

--- a/gloss/sys_exit.c
+++ b/gloss/sys_exit.c
@@ -1,0 +1,8 @@
+#include <mee/shutdown.h>
+
+void
+_exit(int exit_status)
+{
+  mee_shutdown(exit_status);
+  while (1);
+}

--- a/gloss/sys_faccessat.c
+++ b/gloss/sys_faccessat.c
@@ -1,0 +1,8 @@
+#include <errno.h>
+
+int
+_faccessat(int dirfd, const char *file, int mode, int flags)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_fork.c
+++ b/gloss/sys_fork.c
@@ -1,0 +1,8 @@
+#include <errno.h>
+
+int
+_fork()
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_fstat.c
+++ b/gloss/sys_fstat.c
@@ -1,0 +1,9 @@
+#include <errno.h>
+#include <sys/stat.h>
+
+int
+_fstat(int file, struct stat *st)
+{
+  errno = -ENOSYS;
+  return -1;
+}

--- a/gloss/sys_fstatat.c
+++ b/gloss/sys_fstatat.c
@@ -1,0 +1,9 @@
+#include <errno.h>
+#include <sys/stat.h>
+
+int
+_fstatat(int dirfd, const char *file, struct stat *st, int flags)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_ftime.c
+++ b/gloss/sys_ftime.c
@@ -1,0 +1,9 @@
+#include <errno.h>
+#include <sys/timeb.h>
+
+int
+_ftime(struct timeb *tp)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_getcwd.c
+++ b/gloss/sys_getcwd.c
@@ -1,0 +1,8 @@
+#include <errno.h>
+
+char *
+_getcwd(char *buf, size_t size)
+{
+  errno = -ENOSYS;
+  return NULL;
+}

--- a/gloss/sys_getpid.c
+++ b/gloss/sys_getpid.c
@@ -1,0 +1,7 @@
+#include <errno.h>
+
+int
+_getpid()
+{
+  return 1;
+}

--- a/gloss/sys_gettimeofday.c
+++ b/gloss/sys_gettimeofday.c
@@ -1,0 +1,9 @@
+#include <errno.h>
+#include <sys/time.h>
+
+int
+_gettimeofday(struct timeval *tp, void *tzp)
+{
+  errno = -ENOSYS;
+  return -1;
+}

--- a/gloss/sys_isatty.c
+++ b/gloss/sys_isatty.c
@@ -1,0 +1,7 @@
+#include <unistd.h>
+
+int
+_isatty(int file)
+{
+  return (file == STDOUT_FILENO);
+}

--- a/gloss/sys_kill.c
+++ b/gloss/sys_kill.c
@@ -1,0 +1,8 @@
+#include <errno.h>
+
+int
+_kill(int pid, int sig)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_link.c
+++ b/gloss/sys_link.c
@@ -1,0 +1,7 @@
+#include <errno.h>
+
+int _link(const char *old_name, const char *new_name)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_lseek.c
+++ b/gloss/sys_lseek.c
@@ -1,0 +1,9 @@
+#include <sys/types.h>
+#include <errno.h>
+
+off_t
+_lseek(int file, off_t ptr, int dir)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_lstat.c
+++ b/gloss/sys_lstat.c
@@ -1,0 +1,8 @@
+#include <errno.h>
+#include <sys/stat.h>
+
+int _lstat(const char *file, struct stat *st)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_open.c
+++ b/gloss/sys_open.c
@@ -1,0 +1,8 @@
+#include <errno.h>
+
+int
+_open(const char *name, int flags, int mode)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_openat.c
+++ b/gloss/sys_openat.c
@@ -1,0 +1,8 @@
+#include <errno.h>
+
+int
+_openat(int dirfd, const char *name, int flags, int mode)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_read.c
+++ b/gloss/sys_read.c
@@ -1,0 +1,9 @@
+#include <sys/types.h>
+#include <errno.h>
+
+ssize_t
+_read(int file, void *ptr, size_t len)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_sbrk.c
+++ b/gloss/sys_sbrk.c
@@ -1,0 +1,25 @@
+#include <sys/types.h>
+
+/* brk is handled entirely within the C library.  This limits MEE programs that
+ * use the C library to be disallowed from dynamically allocating memory
+ * without talking to the C library, but that sounds like a sane way to go
+ * about it.  Note that there is no error checking anywhere in this file, users
+ * will simply get the relevant error when actually trying to use the memory
+ * that's been allocated. */
+extern char mee_segment_heap_target_start;
+static char *brk = &mee_segment_heap_target_start;
+
+int
+_brk(void *addr)
+{
+  brk = addr;
+  return 0;
+}
+
+char *
+_sbrk(ptrdiff_t incr)
+{
+  char *old = brk;
+  brk += incr;
+  return old;
+}

--- a/gloss/sys_stat.c
+++ b/gloss/sys_stat.c
@@ -1,0 +1,9 @@
+#include <errno.h>
+#include <sys/stat.h>
+
+int
+_stat(const char *file, struct stat *st)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_sysconf.c
+++ b/gloss/sys_sysconf.c
@@ -1,0 +1,16 @@
+#include <unistd.h>
+#include <time.h>
+
+/* Get configurable system variables.  */
+
+long
+_sysconf(int name)
+{
+  switch (name)
+    {
+    case _SC_CLK_TCK:
+      return CLOCKS_PER_SEC;
+    }
+
+  return -1;
+}

--- a/gloss/sys_times.c
+++ b/gloss/sys_times.c
@@ -1,0 +1,9 @@
+#include <sys/times.h>
+#include <errno.h>
+
+clock_t
+_times(struct tms *buf)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_unlink.c
+++ b/gloss/sys_unlink.c
@@ -1,0 +1,8 @@
+#include <errno.h>
+
+int
+_unlink(const char *name)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_utime.c
+++ b/gloss/sys_utime.c
@@ -1,0 +1,9 @@
+#include <errno.h>
+struct utimbuf;
+
+int
+_utime(const char *path, const struct utimbuf *times)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_wait.c
+++ b/gloss/sys_wait.c
@@ -1,0 +1,7 @@
+#include <errno.h>
+
+int _wait(int *status)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/gloss/sys_write.c
+++ b/gloss/sys_write.c
@@ -1,0 +1,19 @@
+#include <mee/tty.h>
+#include <sys/types.h>
+#include <errno.h>
+#include <unistd.h>
+
+/* Write to a file.  */
+ssize_t
+_write(int file, const void *ptr, size_t len)
+{
+  if (file != STDOUT_FILENO) {
+    errno = ENOSYS;
+    return -1;
+  }
+
+  const char *bptr = ptr;
+  for (size_t i = 0; i < len; ++i)
+    mee_tty_putc(bptr[i]);
+  return 0;
+}


### PR DESCRIPTION
We sometimes ship toolchains with an MEE libgloss, but not always.
This allows users to build libgloss directly into libriscv__menv__mee.a,
which may be a cleaner solution.  Note that this libgloss includes crt0
as part of the mee.a, which may not be the correct thing to do.

Signed-off-by: Palmer Dabbelt <palmer@sifive.com>